### PR TITLE
Fix various source typos

### DIFF
--- a/freecad/marz/feature/fretboard.py
+++ b/freecad/marz/feature/fretboard.py
@@ -117,7 +117,7 @@ def fretboardSection(c, r, w, t, v):
 @PureFunctionCache
 def fretboardCone(startRadius, endRadius, thickness, fbd, top):
     """
-    Create a Compund radius solid, result is oriented along `fbd.neckFrame.midLine` with top edge horizontal at z=`top`
+    Create a Compound radius solid, result is oriented along `fbd.neckFrame.midLine` with top edge horizontal at z=`top`
     Args:
         inst : Instrument Data
         fbd  : FraneboardData
@@ -175,7 +175,7 @@ def fretsCut(inst, fbd):
 @PureFunctionCache
 def fretsCutPure(startRadius, endRadius, thickness, tangDepth, tangWidth, nipping, isZeroFret, fbd):
     """
-    Create a Solid with all frets to be cutted from board
+    Create a Solid with all frets to be cut from board
     """
     jobs = []
     bladeHeight = thickness*4
@@ -240,7 +240,7 @@ def nutSlot(inst, fbd):
 @PureFunctionCache
 def nutSlotPure(thickness, depth, fbd): 
     """
-    Create a Nut Solid to be cutted from board
+    Create a Nut Solid to be cut from board
     """
     # Extend the nut frame to bleeding cut
     with traceTime("Nut slot solid"):

--- a/freecad/marz/feature/instrument_properties.py
+++ b/freecad/marz/feature/instrument_properties.py
@@ -43,7 +43,7 @@ properties = [
     fcp('neck.startThickness',          15, 'Thickness at nut position'),
     fcp('neck.endThickness',            15, 'Thickness at heel transition start position'),
     fcp('neck.jointFret',               16, 'Number of fret where heel transition starts', ui='App::PropertyInteger'),
-    fcp('neck.topOffset',               2, 'Offset beteen body top and fretboard bottom'),
+    fcp('neck.topOffset',               2, 'Offset between body top and fretboard bottom'),
     fcp('neck.angle',                   0, 'Break angle', ui='App::PropertyAngle'),
     fcp('neck.tenonThickness',          0, 'Tenon Thickness if Set In Neck'),
     fcp('neck.tenonLength',             0, 'Tenon Length if Set In Neck'),

--- a/freecad/marz/model/fretboard_builder.py
+++ b/freecad/marz/model/fretboard_builder.py
@@ -142,7 +142,7 @@ def buildFretboardData(inst):
 
     nutFrame = calc_nut_frame()
 
-    # Adjust ScaleFrame ans virtStrFrame (Center in Fretboard)
+    # Adjust ScaleFrame and virtStrFrame (Center in Fretboard)
     def adjust_scale_frame():
         diff = frets[0].mid().sub(scaleFrame.nut.mid())
         return (scaleFrame.translate(diff), virtStrFrame.translate(diff))

--- a/freecad/marz/model/headstock_builder.py
+++ b/freecad/marz/model/headstock_builder.py
@@ -170,7 +170,7 @@ def getTransitionWires(tips, contour, pos, angle, profile, voluteOffset, transHb
 
 
 def isTransitionWireValid(ref, wire):
-    """Chech if {wire} is not inside ref or shrinks the loft"""
+    """Check if {wire} is not inside ref or shrinks the loft"""
     cp = wire.copy()
     cp.translate(Vector(ref.CenterOfMass.x - wire.CenterOfMass.x, 0, 0))
     dist, vectors, edges = ref.distToShape(cp)
@@ -373,7 +373,7 @@ def build(pos, angle, profile, thickness, transitionParamHorizontal, voluteRadiu
 
     Arguments:
         pos {Vector} -- Nut position
-        angle {radians} -- Breack angle
+        angle {radians} -- Break angle
         profile {BoundProfile} -- Neck profile builder
         thickness {float} -- Thickness of the headstock plate
         transitionParamHorizontal {float} -- transition stiffness

--- a/freecad/marz/model/instrument.py
+++ b/freecad/marz/model/instrument.py
@@ -247,7 +247,7 @@ class Neck(Feature):
             tenonThickness   : Thickness of the tenon
             tenonLength      : Length of the tenon
             tenonOffset      : Offset of the tenon
-            transitionLength : Lenght of the transition between neck and heel
+            transitionLength : Length of the transition between neck and heel
             transitionTension: Tension of the transition between neck and heel
         """
         super().__init__(instrument)
@@ -380,7 +380,7 @@ class FretWire(Feature):
     def __init__(self, instrument, name=None, tangDepth=None, tangWidth=None, crownHeight=None, crownWidth=None):
         super().__init__(instrument)
         """
-        Paramaters:
+        Parameters:
             name        : Name of FretWire (reference)
             tangDepth   : Tang Depth
             tangWidth   : Tang Width
@@ -410,7 +410,7 @@ class HeadStock(Feature):
                  voluteOffset=10,
                  topTransitionLength=20):
         """
-        Paramaters:
+        Parameters:
             width       : Max width
             length      : Max Length
             thickness   : Thickness
@@ -438,7 +438,7 @@ class Bridge(Feature):
 
     def __init__(self, instrument, stringDistanceProj=63, height=16.363, bassCompensation=0, trebleCompensation=0):
         """
-        Paramaters:
+        Parameters:
             stringDistanceProj  : String distance pojected to perpendicular bridge
             height              : Min Height of the Bridge
             bassCompensation    : Compensation at bass scale
@@ -459,7 +459,7 @@ class Body(Feature):
     def __init__(self, instrument, topThickness=5, backThickness=40, length=500, width=350, neckPocketDepth=15.875,
                  neckPocketLength=50):
         """
-        Paramaters:
+        Parameters:
             topThickness    : Top thickness
             backThickness   : Back thickness
             length          : Length


### PR DESCRIPTION
Found via `codespell -q 3 -S *.svg -L ba,startd,vertexes`