### PR TITLE
allow "_w" or "_w000" ending of path IDs

### DIFF
--- a/freecad/marz/feature/import_svg.py
+++ b/freecad/marz/feature/import_svg.py
@@ -207,14 +207,14 @@ def import_custom_shapes(
         if name == 'contour':
             validation.append(ImportValidationItem('Contour', name, 'Found'))
             contour = obj
-        elif obj.Name == 'midline':
-            validation.append(ImportValidationItem('MidLine', obj.Name, 'Found'))
+        elif name == 'midline':
+            validation.append(ImportValidationItem('MidLine', name, 'Found'))
             midline = obj
-        elif obj.Name == 'transition':
-            validation.append(ImportValidationItem('Transition', obj.Name, 'Found'))
+        elif name == 'transition':
+            validation.append(ImportValidationItem('Transition', name, 'Found'))
             transition = obj
-        elif obj.Name == 'bridge':
-            validation.append(ImportValidationItem('Bridge', obj.Name, 'Found'))
+        elif name == 'bridge':
+            validation.append(ImportValidationItem('Bridge', name, 'Found'))
             bridge = obj
         else:
             extract_pocket(obj, pockets)

--- a/freecad/marz/feature/import_svg.py
+++ b/freecad/marz/feature/import_svg.py
@@ -40,11 +40,11 @@ from freecad.marz.utils import geom
 import Part                     # type: ignore
 from BOPTools import SplitAPI   # type: ignore
 
-NAME_ID_PATTERN = re.compile(r'^(.+)(?:_w\d*)$')
-POCKET_ID_PATTERN = re.compile(r'^h([tb]?)\d+_(\d+)_(\d+)(?:_w\d*)$', re.IGNORECASE)
-FRET_INLAY_ID_PATTERN = re.compile(r'^f(\d+)_.*(?:_w\d*)$', re.IGNORECASE)
-ERGO_CUT_ID_PATTERN = re.compile(r'^ec([tb])_(\d+)(?:_w\d*)$', re.IGNORECASE)
-ERGO_CUT_CTL_ID_PATTERN = re.compile(r'^ec([tb])_(\d+)_(\d+)(?:_w\d*)$', re.IGNORECASE)
+NAME_ID_PATTERN = re.compile(r'^(.+?)(?:_w\d*)?$')
+POCKET_ID_PATTERN = re.compile(r'^h([tb]?)\d+_(\d+)_(\d+)(?:(_\d+)?_w\d*)?$', re.IGNORECASE)
+FRET_INLAY_ID_PATTERN = re.compile(r'^f(\d+)_.*?(?:(_\d+)_w\d*)?$', re.IGNORECASE)
+ERGO_CUT_ID_PATTERN = re.compile(r'^ec([tb])_(\d+)(?:(_\d+)_w\d*)?$', re.IGNORECASE)
+ERGO_CUT_CTL_ID_PATTERN = re.compile(r'^ec([tb])_(\d+)_(\d+)(?:(_\d+)_w\d*)?$', re.IGNORECASE)
 
 def ImportValidationItem(kind: str, reference: str, message: str, start: float = None, depth: float = None):
     return dict(kind=kind, reference=reference, message=message, start=start, depth=depth)

--- a/freecad/marz/feature/import_svg.py
+++ b/freecad/marz/feature/import_svg.py
@@ -40,10 +40,11 @@ from freecad.marz.utils import geom
 import Part                     # type: ignore
 from BOPTools import SplitAPI   # type: ignore
 
-POCKET_ID_PATTERN = re.compile(r'^h([tb]?)\d+_(\d+)_(\d+)$', re.IGNORECASE)
-FRET_INLAY_ID_PATTERN = re.compile(r'^f(\d+)_.*$', re.IGNORECASE)
-ERGO_CUT_ID_PATTERN = re.compile(r'^ec([tb])_(\d+)$', re.IGNORECASE)
-ERGO_CUT_CTL_ID_PATTERN = re.compile(r'^ec([tb])_(\d+)_(\d+)$', re.IGNORECASE)
+NAME_ID_PATTERN = re.compile(r'^(.+)(?:_w\d*)$')
+POCKET_ID_PATTERN = re.compile(r'^h([tb]?)\d+_(\d+)_(\d+)(?:_w\d*)$', re.IGNORECASE)
+FRET_INLAY_ID_PATTERN = re.compile(r'^f(\d+)_.*(?:_w\d*)$', re.IGNORECASE)
+ERGO_CUT_ID_PATTERN = re.compile(r'^ec([tb])_(\d+)(?:_w\d*)$', re.IGNORECASE)
+ERGO_CUT_CTL_ID_PATTERN = re.compile(r'^ec([tb])_(\d+)_(\d+)(?:_w\d*)$', re.IGNORECASE)
 
 def ImportValidationItem(kind: str, reference: str, message: str, start: float = None, depth: float = None):
     return dict(kind=kind, reference=reference, message=message, start=start, depth=depth)
@@ -198,8 +199,13 @@ def import_custom_shapes(
     for obj in tmp_doc.Objects:
         if match_ergo_cut(obj, ergo_cuts):
             continue
-        elif obj.Name == 'contour':
-            validation.append(ImportValidationItem('Contour', obj.Name, 'Found'))
+
+        m = NAME_ID_PATTERN.match(obj.Name)
+        if not m:
+            continue
+        name = m.group(1)
+        if name == 'contour':
+            validation.append(ImportValidationItem('Contour', name, 'Found'))
             contour = obj
         elif obj.Name == 'midline':
             validation.append(ImportValidationItem('MidLine', obj.Name, 'Found'))


### PR DESCRIPTION
Closes #50

Apparently, Hungarian Notation got its foot into ImportSVG's door. With the recent Import SVG changes, all wires (eg. all shapes with no fill or no closing) get a "_w" suffix (see FreeCAD/FreeCAD@5f8eac49f31626354ee69bf40616bac801ca5560, https://github.com/FreeCAD/FreeCAD/blob/5f8eac49f31626354ee69bf40616bac801ca5560/src/Mod/Draft/SVGPath.py#L768).

Supporting Number of copies suffix might be not required (as they appear only repeated imports), but I certainly had them when I tested it multiple times in python console.